### PR TITLE
removed +1 for $base_url_count to correct panels display

### DIFF
--- a/maincore.php
+++ b/maincore.php
@@ -105,7 +105,7 @@ define("FUSION_ROOT", $fusion_root);
 // Calculate current true url
 $script_url = explode("/", $_SERVER['PHP_SELF']);
 $url_count = count($script_url);
-$base_url_count = substr_count(BASEDIR, "/")+1;
+$base_url_count = substr_count(BASEDIR, "/");
 $current_page = "";
 while ($base_url_count != 0) {
 	$current = $url_count-$base_url_count;


### PR DESCRIPTION
as now BASADIR is ./ and the old code written for BASEDIR=. it gave extra / in TRUE_PHP_SELF - leeds to error in display of panels (if you want to display panel on certain page)