### PR TITLE
Download infusion cannot have default value for TEXT fields

### DIFF
--- a/infusions/downloads/infusion.php
+++ b/infusions/downloads/infusion.php
@@ -45,7 +45,7 @@ $inf_newtable[] = DB_DOWNLOADS." (
 	download_keywords VARCHAR(250) NOT NULL DEFAULT '',
 	download_image VARCHAR(100) NOT NULL DEFAULT '',
 	download_image_thumb VARCHAR(100) NOT NULL DEFAULT '',
-	download_url TEXT NOT NULL DEFAULT '',
+	download_url TEXT NOT NULL,
 	download_file VARCHAR(100) NOT NULL DEFAULT '',
 	download_cat MEDIUMINT(8) UNSIGNED NOT NULL DEFAULT '0',
 	download_license VARCHAR(50) NOT NULL DEFAULT '',


### PR DESCRIPTION
See https://dev.mysql.com/doc/refman/5.0/en/blob.html

     BLOB and TEXT columns cannot have DEFAULT values.