### PR TITLE
Fix the wrong font at icon overview in a section (e.g.: Content Admin).

### DIFF
--- a/themes/admin_themes/Old_School/acp_styles.css
+++ b/themes/admin_themes/Old_School/acp_styles.css
@@ -304,11 +304,13 @@ table {
 	font-size:14px;
 	display: inline-block;
 	color: rgb(51,51,51);
+    font-family: Arial, sans-serif;
 }
 
 .icon-container .icon-description {
 	font-size:13px;
 	color: rgb(119,119,119);
+    font-family: Arial, sans-serif;
 }
 
 /* Fieldset & Legend styles */	

--- a/themes/admin_themes/Venus/acp_styles.css
+++ b/themes/admin_themes/Venus/acp_styles.css
@@ -277,11 +277,13 @@ table {
 	font-size:14px;
 	display: inline-block;
 	color: rgb(51,51,51);
+    font-family: Arial, sans-serif;
 }
 
 .icon-container .icon-description {
 	font-size:13px;
 	color: rgb(119,119,119);
+    font-family: Arial, sans-serif;
 }
 
 /* Fieldset & Legend styles */	


### PR DESCRIPTION
This happened because everything that is called "icon-" will get the "entypo" font which is not wanted here.