### PR TITLE
Removed <br /> and wrap help in a block element.

### DIFF
--- a/includes/dynamics/includes/form_text.php
+++ b/includes/dynamics/includes/form_text.php
@@ -162,9 +162,7 @@ function form_text($input_name, $label = "", $input_value = "", array $options =
 
     $html .= ($options['append_button'] || $options['prepend_button'] || $options['append_value'] || $options['prepend_value']) ? "</div>\n" : "";
 
-    $html .= ($defender->inputHasError($input_name) && (!$options['inline'] || $options['append_button'] || $options['prepend_button'] || $options['append_value'] || $options['prepend_value']) ? "<br/>" : "");
-
-    $html .= $defender->inputHasError($input_name) ? "<div id='".$options['input_id']."-help' class='label label-danger p-5 display-inline-block'>".$options['error_text']."</div>" : "";
+    $html .= $defender->inputHasError($input_name) ? "<div class='input-error ".((!$options['inline'] || $options['append_button'] || $options['prepend_button'] || $options['append_value'] || $options['prepend_value']) ? "display-block" : "")."'><div id='".$options['input_id']."-help' class='label label-danger p-5 display-inline-block'>".$options['error_text']."</div></div>" : "";
 
     $html .= ($options['inline'] && $label) ? "</div>\n" : "";
 

--- a/includes/dynamics/includes/form_text.php
+++ b/includes/dynamics/includes/form_text.php
@@ -162,7 +162,7 @@ function form_text($input_name, $label = "", $input_value = "", array $options =
 
     $html .= ($options['append_button'] || $options['prepend_button'] || $options['append_value'] || $options['prepend_value']) ? "</div>\n" : "";
 
-    $html .= $defender->inputHasError($input_name) ? "<div class='input-error ".((!$options['inline'] || $options['append_button'] || $options['prepend_button'] || $options['append_value'] || $options['prepend_value']) ? "display-block" : "")."'><div id='".$options['input_id']."-help' class='label label-danger p-5 display-inline-block'>".$options['error_text']."</div></div>" : "";
+    $html .= $defender->inputHasError($input_name) ? "<div class='input-error".((!$options['inline'] || $options['append_button'] || $options['prepend_button'] || $options['append_value'] || $options['prepend_value']) ? " display-block" : "")."'><div id='".$options['input_id']."-help' class='label label-danger p-5 display-inline-block'>".$options['error_text']."</div></div>" : "";
 
     $html .= ($options['inline'] && $label) ? "</div>\n" : "";
 


### PR DESCRIPTION
The break here was looking ugly so I wrapped the help in a div with display block class if the field is not inline.
I tested this on several pages and did not find any problem.