### PR TITLE
Add an additional check her to suppress an error in our log.

### DIFF
--- a/includes/class.httpdownload.php
+++ b/includes/class.httpdownload.php
@@ -148,7 +148,7 @@ class httpdownload {
 			@ob_end_clean();
 		}
 		$old_status = ignore_user_abort(TRUE);
-		if (!ini_get('safe_mode')) {
+		if (!ini_get('safe_mode') && function_exists("set_time_limit")) {
 			@set_time_limit(0);
 		}
 		$this->bandwidth = 0;
@@ -209,7 +209,7 @@ class httpdownload {
 		if ($this->use_autoexit) exit();
 		//restore old status
 		ignore_user_abort($old_status);
-		if (!ini_get('safe_mode')) {
+		if (!ini_get('safe_mode') && function_exists("set_time_limit")) {
 			@set_time_limit(ini_get("max_execution_time"));
 		}
 		return TRUE;


### PR DESCRIPTION
As @Webmeteor pointed out:
http://phpfusion-deutschland.de/forum/viewthread.php?thread_id=744&pid=4437#post_4437
the "set_time_limit()" function is disabled due to security reasons by some hosts.

I add an additional check here to suppress the error message.