### PR TITLE
Update db_exists

### DIFF
--- a/includes/sqlhandler.inc.php
+++ b/includes/sqlhandler.inc.php
@@ -863,17 +863,19 @@ function getcategory($cat) {
  *    Pass TRUE if you want to update the cached state of the table.
  * @return boolean
  */
-function db_exists($table, $updateCache = FALSE) {
+function db_exists($table) {
 
     if (strpos($table, DB_PREFIX) === FALSE) {
         $table = DB_PREFIX.$table;
     }
-    $sql = "SHOW TABLES LIKE '%".$table."%'";
-    $result = dbquery($sql);
-    if (dbrows($result)) {
-        return TRUE;
+	
+    $query = dbquery("SHOW TABLES");
+    while($row = dbarraynum($query)){
+	    if($row[0] == $table){
+		   return true; 
+	    }
     }
-    return FALSE;
+    return false;
 }
 
 /**


### PR DESCRIPTION
If you have a table "tests" and call it as db_exists("test") it will return true. This is wrong becuse test not exists but tests do. There for wee need to render all table name to find out it dont exists...