### PR TITLE
Prevent XSS attacks in username in Magazine theme login form.

### DIFF
--- a/themes/Magazine/classes/Templates/Login.inc
+++ b/themes/Magazine/classes/Templates/Login.inc
@@ -82,7 +82,7 @@ class Login extends Core {
             }
 
             echo $info['open_form'];
-            echo form_text('user_name', '', isset($_POST['user_name']) ? $_POST['user_name'] : '', ['placeholder' => $placeholder]);
+            echo form_text('user_name', '', isset($_POST['user_name']) ? form_sanitizer($_POST['user_name'], '', 'user_name') : '', ['placeholder' => $placeholder]);
             echo form_text('user_pass', '', '', ['placeholder' => $locale['global_102'], 'type' => 'password']);
             echo form_checkbox('remember_me', $locale['global_103'], '', ['reverse_label' => TRUE]);
             echo $info['login_button'];


### PR DESCRIPTION
form_text() doesn't sanitize $input_value, so I use form_sanitizer().

![php-fusion-xss-login-username](https://user-images.githubusercontent.com/1123530/47729223-d43cc380-dc70-11e8-8d45-c62ed7a1540c.png)

But may be there is no need to display wrong username.