### PR TITLE
Prevent self XSS attacks in username in edit_profile.

### DIFF
--- a/includes/classes/PHPFusion/UserFields.inc
+++ b/includes/classes/PHPFusion/UserFields.inc
@@ -146,7 +146,7 @@ class UserFields extends QuantumFields {
 
         if ($_GET['section'] == 1) {
 
-            $user_name = isset($_POST['user_name']) ? $_POST['user_name'] : $this->userData['user_name'];
+            $user_name = isset($_POST['user_name']) ? form_sanitizer($_POST['user_name'], '', 'user_name') : $this->userData['user_name'];
             $user_email = isset($_POST['user_email']) ? $_POST['user_email'] : $this->userData['user_email'];
             $user_hide_email = isset($_POST['user_hide_email']) ? $_POST['user_hide_email'] : $this->userData['user_hide_email'];
             $this->info['user_name'] = form_para($locale['u129'], 'account', 'profile_category_name');


### PR DESCRIPTION
form_text() doesn't sanitize $input_value, so I use form_sanitizer().

![php-fusion-xss-edit-profile-username](https://user-images.githubusercontent.com/1123530/47771575-ed875380-dcf4-11e8-900a-f94b95cec795.png)
