### PR TITLE
Prevent XSS attacks in search_text in display_members().

### DIFF
--- a/includes/classes/PHPFusion/Members.inc
+++ b/includes/classes/PHPFusion/Members.inc
@@ -205,7 +205,7 @@ class Members {
             }
 
 
-            $info['no_result'] = self::$locale['MEMB_018'].(isset($_GET['search_text']) ? $_GET['search_text'] : $_GET['sortby']);
+            $info['no_result'] = self::$locale['MEMB_018'].(isset($_GET['search_text']) ? form_sanitizer($_GET['search_text'], '', 'search_text') : $_GET['sortby']);
 
             $info += $this->default_info;
             render_members($info);

--- a/includes/classes/PHPFusion/Members.inc
+++ b/includes/classes/PHPFusion/Members.inc
@@ -96,7 +96,7 @@ class Members {
 
             $search_form = openform('searchform', 'get', BASEDIR."members.php?");
             $search_form .= "<div class='display-inline-block pull-left m-r-10' style='width:300px;'>\n";
-            $search_form .= form_text('search_text', '', $_GET['search_text'],
+            $search_form .= form_text('search_text', '', form_sanitizer($_GET['search_text'], '', 'search_text'),
                 [
                     'inline'             => TRUE,
                     'placeholder'        => self::$locale['MEMB_005'],


### PR DESCRIPTION
form_text() doesn't sanitize $input_value, so I use form_sanitizer().

![php-fusion-xss-members-search_text](https://user-images.githubusercontent.com/1123530/47775086-c71ae580-dcff-11e8-8e35-6e1a05c9777c.png)

![php-fusion-xss-members-search_text-2](https://user-images.githubusercontent.com/1123530/47776549-b1a7ba80-dd03-11e8-8923-bcd5505370b3.PNG)
