### PR TITLE
Prevent XSS attacks via msg_read in private messages.

### DIFF
--- a/includes/classes/PHPFusion/PrivateMessages.inc
+++ b/includes/classes/PHPFusion/PrivateMessages.inc
@@ -466,7 +466,7 @@ class PrivateMessages {
         if (isset($_GET['msg_read'])) {
             // this is the read menu.
             $html = openform('actionform', 'post', FUSION_REQUEST);
-            $html .= form_hidden('selectedPM', '', $_GET['msg_read']);
+            $html .= form_hidden('selectedPM', '', intval($_GET['msg_read']));
             $html .= "<div class='btn-group display-inline-block m-r-10'>\n";
             if ($_GET['folder'] == "archive") {
                 $html .= form_button('unarchive_pm', $this->locale['413'], 'unarchive_pm', ['icon' => 'fa fa-unlock']);


### PR DESCRIPTION
form_hidden() doesn't sanitize $input_value, so I use intval() on msg_read.

![php-fusion-xss-members-msg_read](https://user-images.githubusercontent.com/1123530/47808076-ab8afb80-dd4e-11e8-8b6d-207b81cb583f.PNG)