### PR TITLE
Proper gateway fix

### DIFF
--- a/gateway/functions_include.php
+++ b/gateway/functions_include.php
@@ -45,22 +45,31 @@ function convertNumberToWord($num = FALSE) {
     for ($i = 0; $i < count($num_levels); $i++) {
         $levels--;
         $hundreds = (int)($num_levels[$i] / 100);
-        $hundreds = ($hundreds ? ' '.$list1[$hundreds].$locale['gateway_051'].' ' : '');
+        if ( $hundreds ) {
+            $words[] = $list1[$hundreds].$locale['gateway_051'];
+        }
         $tens = (int)($num_levels[$i] % 100);
         $singles = '';
         if ($tens < 20) {
-            $tens = ($tens ? ' '.$list1[$tens].' ' : '');
+            if ( $tens ) {
+                $words[] = $list1[$tens];
+            }
         } else {
             $tens = (int)($tens / 10);
-            $tens = ' '.$list2[$tens].' ';
+            if ( $tens ) {
+                $words[] = $list2[$tens];
+            }
             $singles = (int)($num_levels[$i] % 10);
-            $singles = ' '.$list1[$singles].' ';
+            if( $singles ) {
+                $words[] = $list1[$singles];
+            }
         }
-        $words[] = $hundreds.$tens.$singles.(($levels && (int)($num_levels[$i])) ? ' '.$list3[$levels].' ' : '');
+        if ( $levels && (int)($num_levels[$i]) ) {
+            $words[] = $list3[$levels];
+        }
     }
 
-    $words = str_replace(' ', '', $words);
-    return implode($words);
+    return implode(' ', $words);
 }
 
 if (!function_exists('str_rot47')) {

--- a/locale/English/gateway.php
+++ b/locale/English/gateway.php
@@ -71,7 +71,7 @@ $locale['gateway_063'] = "Numbers";
 $locale['gateway_064'] = "You must answer the question";
 $locale['gateway_065'] = "Proceed";
 
-$locale['gateway_066'] = "Your answer is incorrect!<br/>Please write all answers in one line. Example: twentysix or nineteen";
+$locale['gateway_066'] = "Your answer is incorrect!";
 $locale['gateway_067'] = "Try Again!";
 $locale['gateway_068'] = "Please try again later!";
 $locale['gateway_069'] = "Fusion GateWay";


### PR DESCRIPTION
Adding spaces manually between hundreds, tens, singles and num_levels resulted in multiple spaces between words and even at the beginning and the end of the string, causing correct answers to fail. Instead of removing spaces entirely, all answer parts can be pushed to a words table and implode function will handle spaces between words correctly.