### PR TITLE
BBcode should disable referrer on external links, images and iframes.

### DIFF
--- a/includes/bbcodes/!autolink_bbcode_include.php
+++ b/includes/bbcodes/!autolink_bbcode_include.php
@@ -25,7 +25,7 @@ if (!function_exists('PHPFusion\BBCode\Autolink\run')) {
             $text = str_replace("[", " &#91;", $text);
             $text = str_replace("]", "&#93; ", $text);
         } else if ($part == 2) {
-            $text = preg_replace('^<a href="(.*?)" target="_blank" title="autolink" rel="nofollow">(.*?)</a>^si', '\1', $text);
+            $text = preg_replace('^<a href="(.*?)" target="_blank" title="autolink" rel="nofollow noopener noreferrer">(.*?)</a>^si', '\1', $text);
             $text = str_replace(" &#91;", "&#91;", $text);
             $text = str_replace("&#93; ", "&#93;", $text);
         }
@@ -60,7 +60,7 @@ if (!function_exists('PHPFusion\BBCode\Autolink\run')) {
     function callbackURLWithProtocol($matches) {
         $len = strlen($matches[2]);
 
-        return $matches[1].'<a href="'.$matches[2].'" target="_blank" title="autolink" rel="nofollow">'
+        return $matches[1].'<a href="'.$matches[2].'" target="_blank" title="autolink" rel="nofollow noopener noreferrer">'
             .trimlink($matches[2], 20)
             .($len > 30 ? substr($matches[2], $len - 10, $len) : '').'</a>';
     }
@@ -68,7 +68,7 @@ if (!function_exists('PHPFusion\BBCode\Autolink\run')) {
     function callbackURLWithoutProtocol($matches) {
         $len = strlen($matches[2]);
 
-        return $matches[1].'<a href="http://'.$matches[2].'" target="_blank" title="autolink" rel="nofollow">'
+        return $matches[1].'<a href="http://'.$matches[2].'" target="_blank" title="autolink" rel="nofollow noopener noreferrer">'
             .trimlink($matches[2], 20)
             .(strlen($matches[1]) > 30 ? substr($matches[2], $len - 10, $len) : '').'</a>';
     }

--- a/includes/bbcodes/img_bbcode_include.php
+++ b/includes/bbcodes/img_bbcode_include.php
@@ -23,7 +23,7 @@ if (!function_exists("img_bbcode_callback")) {
             return "<span class='forum-img-wrapper'><img src='".$matches[1].str_replace(
                     ["?", "&amp;", "&", "="],
                     "",
-                    $matches[3]).$matches[4]."' alt='".$matches[3].$matches[4]."' style='border:0px' class='img-responsive forum-img' /></span>";
+                    $matches[3]).$matches[4]."' alt='".$matches[3].$matches[4]."' style='border:0px' class='img-responsive forum-img' referrerpolicy='no-referrer' /></span>";
         } else {
             return $matches[0];
         }

--- a/includes/bbcodes/url_bbcode_include.php
+++ b/includes/bbcodes/url_bbcode_include.php
@@ -30,7 +30,7 @@ if (!function_exists('replace_url')) {
         $content = (empty($m['url']) ? trimlink($m['content'], 40).(strlen($m['content']) > 40 ? substr($m['content'], strlen($m['content']) - 10,
                 strlen($m['content'])) : '') : $m['content']);
 
-        return ($index_url_bbcode ? "" : "<!--noindex-->")."<a href='$this_url' target='_blank' ".($index_url_bbcode ? "" : "rel='nofollow' ")."title='".urldecode($this_url)."'>".$content."</a>".($index_url_bbcode ? "" : "<!--/noindex-->");
+        return ($index_url_bbcode ? "" : "<!--noindex-->")."<a href='$this_url' target='_blank' ".($index_url_bbcode ? "" : "rel='nofollow noopener noreferrer' ")."title='".urldecode($this_url)."'>".$content."</a>".($index_url_bbcode ? "" : "<!--/noindex-->");
     }
 }
 

--- a/includes/bbcodes/youtube_bbcode_include.php
+++ b/includes/bbcodes/youtube_bbcode_include.php
@@ -17,5 +17,5 @@
 +--------------------------------------------------------*/
 defined('IN_FUSION') || exit;
 
-$html = '<div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item" src="https://www.youtube.com/embed/\3" allowfullscreen></iframe></div>';
+$html = '<div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item" src="https://www.youtube.com/embed/\3" referrerpolicy="no-referrer" allowfullscreen></iframe></div>';
 $text = preg_replace('#\[youtube\](http:|https:)?(\/\/www.youtube\.com\/watch\?v=|\/\/youtu\.be\/)?(.*?)\[/youtube\]#si', $html, $text);


### PR DESCRIPTION
BBcode should disable referrer on external links, images and iframes.

The modern web is full of tracking by advertisement agencies and other companies that build and sell user profiles. The HTTP Referrer header is an old part of the web, but gets used by these tracking companies and should be discouraged in my opinion.
Not sending referrers on external links, images and iframes improves privacy for visitors of the webites.

Also part of the patch is the addition of noopener, which cuts down on the access the linked page gets to the original page through the 'window.opener' object in JavaScript. This will also improve privacy and security for visitors.