### PR TITLE
Fix rowstart in forum links.

### DIFF
--- a/infusions/forum_threads_list_panel/forum_threads_list_panel.php
+++ b/infusions/forum_threads_list_panel/forum_threads_list_panel.php
@@ -68,7 +68,7 @@ if (defined('FORUM_EXIST')) {
             $thread_rowstart = '';
             if (!empty($data['thread_postcount']) && !empty($inf_settings['posts_per_page'])) {
                 if ($data['thread_postcount'] > $inf_settings['posts_per_page']) {
-                    $thread_rowstart = $inf_settings['posts_per_page'] * floor($data['thread_postcount'] / $inf_settings['posts_per_page']);
+                    $thread_rowstart = $inf_settings['posts_per_page'] * floor(($data['thread_postcount'] - 1) / $inf_settings['posts_per_page']);
                     $thread_rowstart = "&amp;rowstart=".$thread_rowstart;
                 }
             }

--- a/infusions/forum_threads_list_panel/my_posts.php
+++ b/infusions/forum_threads_list_panel/my_posts.php
@@ -67,7 +67,7 @@ if ($rows) {
                             $counter = 1;
                             while ($thread_post_data = dbarray($thread_posts)) {
                                 if ($thread_post_data['post_id'] == $data['post_id']) {
-                                    $thread_rowstart = $inf_settings['posts_per_page'] * floor($counter / $inf_settings['posts_per_page']);
+                                    $thread_rowstart = $inf_settings['posts_per_page'] * floor(($counter - 1) / $inf_settings['posts_per_page']);
                                     $thread_rowstart = "&amp;rowstart=".$thread_rowstart;
                                 }
                                 $counter++;

--- a/infusions/forum_threads_list_panel/my_threads.php
+++ b/infusions/forum_threads_list_panel/my_threads.php
@@ -61,7 +61,7 @@ if ($rows) {
                     $thread_rowstart = '';
                     if (!empty($data['thread_postcount']) && !empty($inf_settings['posts_per_page'])) {
                         if ($data['thread_postcount'] > $inf_settings['posts_per_page']) {
-                            $thread_rowstart = $inf_settings['posts_per_page'] * floor($data['thread_postcount'] / $inf_settings['posts_per_page']);
+                            $thread_rowstart = $inf_settings['posts_per_page'] * floor(($data['thread_postcount'] - 1) / $inf_settings['posts_per_page']);
                             $thread_rowstart = "&amp;rowstart=".$thread_rowstart;
                         }
                     }

--- a/infusions/forum_threads_list_panel/my_tracked_threads.php
+++ b/infusions/forum_threads_list_panel/my_tracked_threads.php
@@ -77,7 +77,7 @@ if ($rows) {
                     $thread_rowstart = '';
                     if (!empty($data['thread_postcount']) && !empty($inf_settings['posts_per_page'])) {
                         if ($data['thread_postcount'] > $inf_settings['posts_per_page']) {
-                            $thread_rowstart = $inf_settings['posts_per_page'] * floor($data['thread_postcount'] / $inf_settings['posts_per_page']);
+                            $thread_rowstart = $inf_settings['posts_per_page'] * floor(($data['thread_postcount'] - 1) / $inf_settings['posts_per_page']);
                             $thread_rowstart = "&amp;rowstart=".$thread_rowstart;
                         }
                     }

--- a/infusions/forum_threads_list_panel/new_posts.php
+++ b/infusions/forum_threads_list_panel/new_posts.php
@@ -73,7 +73,7 @@ if ($rows) {
                         $counter = 1;
                         while ($thread_post_data = dbarray($thread_posts)) {
                             if ($thread_post_data['post_id'] == $data['post_id']) {
-                                $thread_rowstart = $inf_settings['posts_per_page'] * floor($counter / $inf_settings['posts_per_page']);
+                                $thread_rowstart = $inf_settings['posts_per_page'] * floor(($counter - 1) / $inf_settings['posts_per_page']);
                                 $thread_rowstart = "&amp;rowstart=".$thread_rowstart;
                             }
                             $counter++;


### PR DESCRIPTION
Fix rowstart in forum links.
With 39 posts it should go to page 2 with rowstart=20, not rowstart=40.